### PR TITLE
[BUG] Fix polygon to take into account the y coordinate

### DIFF
--- a/drawille.py
+++ b/drawille.py
@@ -267,9 +267,9 @@ def polygon(center_x=0, center_y=0, sides=4, radius=4):
         a = n*degree
         b = (n+1)*degree
         x1 = (center_x+math.cos(math.radians(a)))*(radius+1)/2
-        y1 = (center_x+math.sin(math.radians(a)))*(radius+1)/2
+        y1 = (center_y+math.sin(math.radians(a)))*(radius+1)/2
         x2 = (center_x+math.cos(math.radians(b)))*(radius+1)/2
-        y2 = (center_x+math.sin(math.radians(b)))*(radius+1)/2
+        y2 = (center_y+math.sin(math.radians(b)))*(radius+1)/2
 
         for x,y in line(x1,y1,x2,y2):
             yield x,y


### PR DESCRIPTION
Previously, the x center was used for both y and x coordinate calculations. I changed polygon to use center_y for the y coord calculations instead of center_x which fixes the problem.
