### PR TITLE
[doc] add link to haskell implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ along with drawille. If not, see < http://www.gnu.org/licenses/ >.
  * [https://github.com/mydzor/bash-drawille](https://github.com/mydzor/bash-drawille) (bash)
  * [https://github.com/hoelzro/term-drawille](https://github.com/hoelzro/term-drawille) (perl 5)
  * [https://github.com/whatthejeff/php-drawille](https://github.com/whatthejeff/php-drawille) (PHP)
+ * [https://github.com/yamadapc/haskell-drawille](https://github.com/yamadapc/haskell-drawille) (haskell)
 
 
 ### Further reading


### PR DESCRIPTION
I made a (_partial_) implementation of your lib in haskell (https://github.com/yamadapc/haskell-drawille). I'm still working on the internals, cleaning-up and adding examples, but the core implementation is there.

This simply adds a link to it, even though it probably will never be run...
Haha :)
