### PR TITLE
drawille.py: print BRAILLE PATTERN BLANK (U+2800) in place of SPACE

### DIFF
--- a/drawille.py
+++ b/drawille.py
@@ -228,7 +228,7 @@ class Canvas(object):
                 char = self.chars[rownum].get(x)
 
                 if not char:
-                    row.append(' ')
+                    row.append(unichr(braille_char_offset))
                 elif type(char) != int:
                     row.append(char)
                 else:


### PR DESCRIPTION
In some fonts SPACE (U+20) has different width than
BRAILLE PATTERN BLANK (U+2800) (and the width of the latter
is usually the same as the width of other BRAILLE glyphs).

With pure BRAILLE character output (i.e. no embedded text) the
output is usually good if BRAILLE PATTERN BLANK character is
printed when there is no dots to be set in a character; regardless
of the font used.