### PR TITLE
Added Java port to 'similar projects' list

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ along with drawille. If not, see < http://www.gnu.org/licenses/ >.
 
 ### Other implementations / similar projects
 
+ * [https://github.com/null93/drawille](https://github.com/null93/drawille) (Java)
  * [https://github.com/madbence/node-drawille](https://github.com/madbence/node-drawille) (nodejs)
  * [https://github.com/exrook/drawille-go](https://github.com/exrook/drawille-go) (go)
  * [https://github.com/maerch/ruby-drawille](https://github.com/maerch/ruby-drawille) (ruby)


### PR DESCRIPTION
Created Java port for drawille: https://github.com/null93/drawille