### PR TITLE
Fix empty braille char

### DIFF
--- a/drawille.py
+++ b/drawille.py
@@ -228,7 +228,7 @@ class Canvas(object):
                 char = self.chars[rownum].get(x)
 
                 if not char:
-                    row.append(unichr(braille_char_offset))
+                    row.append(" ")
                 elif type(char) != int:
                     row.append(char)
                 else:


### PR DESCRIPTION
Some fonts display the empty braille char weirdly. Using just a space fixes this.

See https://github.com/gooofy/drawilleplot/issues/4